### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "mitt": "^3.0.1",
     "serve-static": "^1.15.0",
     "vue": "^3.2.13",
-    "vue-cli-service": "^5.0.10"
+    "vue-cli-service": "^5.0.10",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.16",

--- a/server.js
+++ b/server.js
@@ -1,8 +1,18 @@
 const express = require('express')
 const serveStatic = require('serve-static')
 const path = require('path')
+const RateLimit = require('express-rate-limit')
 
 const app = express()
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // max 100 requests per windowMs
+})
+
+// apply rate limiter to all requests
+app.use(limiter)
 
 //here we are configuring dist to serve app files
 app.use('/', serveStatic(path.join(__dirname, '/dist')))


### PR DESCRIPTION
Potential fix for [https://github.com/bcarpe1/plannel-apps/security/code-scanning/1](https://github.com/bcarpe1/plannel-apps/security/code-scanning/1)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` middleware, which allows us to easily set up rate limiting for all incoming requests. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes, which is a reasonable default. This will help protect the application from potential denial-of-service attacks.

We will need to:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `server.js` file.
3. Configure the rate limiter with the desired settings.
4. Apply the rate limiter to all incoming requests using `app.use`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
